### PR TITLE
Create ext.properties

### DIFF
--- a/fmod/ext.properties
+++ b/fmod/ext.properties
@@ -1,0 +1,23 @@
+[fmod]
+group = Runtime
+help = Settings for FMOD extension
+title = FMOD
+
+speaker_mode.type = string
+speaker_mode.default = default
+speaker_mode.options = default, raw, mono, stereo, quad, surround, 5.1, 7.1, max
+
+num_buffers.type = integer
+
+sample_rate.type = integer
+
+num_raw_speakers.type = integer
+
+run_while_iconified.type = bool
+
+live_update.type = bool
+live_update.default = 0
+
+lib_path.type = string
+
+buffer_length.type = integer

--- a/fmod/ext.properties
+++ b/fmod/ext.properties
@@ -7,17 +7,9 @@ speaker_mode.type = string
 speaker_mode.default = default
 speaker_mode.options = default, raw, mono, stereo, quad, surround, 5.1, 7.1, max
 
-num_buffers.type = integer
-
-sample_rate.type = integer
-
 num_raw_speakers.type = integer
-
-run_while_iconified.type = bool
 
 live_update.type = bool
 live_update.default = 0
 
 lib_path.type = string
-
-buffer_length.type = integer


### PR DESCRIPTION
[Soon](https://github.com/defold/defold/pull/11125), it will be possible to view settings from extensions in `game.project` form:

<img width="834" height="762" alt="Screenshot 2025-08-22 at 13 26 15" src="https://github.com/user-attachments/assets/f8907348-04c7-452b-8622-72a768b35bc1" />

I noticed that fallback config values are different depending on the platform for some keys like `num_buffers`, `sample_rate`, `run_while_iconified`, and `buffer_length`. Specifying them in ext.properties would disable their dynamic selection since defaults will be "provided" in `game.project`, so I omitted them.